### PR TITLE
Allow binding functions

### DIFF
--- a/polyfill/tasklet-polyfill.js
+++ b/polyfill/tasklet-polyfill.js
@@ -35,7 +35,16 @@
         callPath = [];
         return r;
       },
-      async apply(_, __, argumentsList, proxy) {
+      apply(_, __, argumentsList, proxy) {
+        // We use `bind` as an indicator to have a remote function bound locally.
+        // The actual target for `bind()` is currently ignored.
+        if(callPath[callPath.length - 1] === 'bind') {
+          const localCallPath = callPath.slice();
+          callPath = [];
+          return (...args) => {
+            return cb('APPLY', localCallPath.slice(0, -1), args);
+          }
+        }
         const r = cb('APPLY', callPath, argumentsList);
         callPath = [];
         return r;

--- a/polyfill/tests/tests.js
+++ b/polyfill/tests/tests.js
@@ -33,6 +33,13 @@ describe('Tasklet Polyfill', function() {
     expect(await instance.getAnswer()).to.equal(42);
   });
 
+  it('can bind methods from an exported class', async function() {
+    const tasklet = await tasklets.addModule('/base/tests/fixtures/simple_class.js');
+    const instance = await new tasklet.SimpleClass();
+    const method = instance.getAnswer.bind(instance);
+    expect(await method()).to.equal(42);
+  });
+
   it('can invoke methods on an instance multiple times even', async function() {
     const tasklet = await tasklets.addModule('/base/tests/fixtures/simple_class.js');
     const instance = await new tasklet.SimpleClass();


### PR DESCRIPTION
Fixes #19 

It doesn’t quite adhere to the semantics of `bind` as we’d have to potentially proxy values from main thread to tasklet, but it covers the 99% use-case I’d say.

@bfgeek PTAL